### PR TITLE
50 move rule Bug fix, terminate game when 50 move rule is reached, py…

### DIFF
--- a/training/generate_games.py
+++ b/training/generate_games.py
@@ -121,8 +121,12 @@ try:
         game.headers["White"] = "LeelaZero_White"
         game.headers["Black"] = "LeelaZero_Black"
 
+        game_drawn=0
         try:
             while not board.is_game_over():
+                if (board.can_claim_fifty_moves()):
+                    game_drawn=1
+                    break
                 if board.turn == chess.WHITE:
                     # White's turn
                     result = engine1.play(board, depth_limit_w)
@@ -138,15 +142,20 @@ try:
             continue
 
         # Game over, set the result
-        game.headers["Result"] = board.result()
+        if (game_drawn==1):
+                game.headers["Result"] = "1/2-1/2"
+        else:
+                game.headers["Result"] = board.result()
 
-        match board.result():
-            case '1-0':
+        if (game_drawn==0):
+            if board.result() == '1-0':
                 wins += 1
-            case '0-1':
+            elif board.result() == '0-1':
                 losses += 1
-            case _:
+            else:
                 draws += 1
+        else:
+            draws +=1
 
         # Calculate total games
         total_games = wins + draws + losses


### PR DESCRIPTION
This is a fix for a bug where lc0 assumes that a game terminates when 50 move rule is reached, but python chess continues requesting moves till 75 move rule is reached, hence lc0 outputs, the worst move from the point that it thinks the 50 move rule is reached and many times this is a blunder and loses, so instead of a draw you get a loss. Do check the the impact of this PR on runtime. This bug is less critical for odds chess where draw by 50-move rule is much less common, so testing before merging is highly advised.